### PR TITLE
Custom labels allowed in U-Matrix

### DIFF
--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -46,7 +46,7 @@ class UMatrixView(MatplotView):
             
         if labels:
             if labels == True:
-              labels = self._dlabel
+              labels = som.build_data_labels()
             for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
                 plt.annotate(
                     label, 

--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -48,14 +48,7 @@ class UMatrixView(MatplotView):
             if labels == True:
               labels = som.build_data_labels()
             for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
-                plt.annotate(
-                    label, 
-                    xy = (x, y),
-                    horizontalalignment = 'center', verticalalignment = 'center'
-                    ) #, xytext = (-20, 20),
-      #                        textcoords = 'offset points', ha = 'right', va = 'bottom',
-      #                       bbox = dict(boxstyle = 'round,pad=0.5', fc = 'yellow', alpha = 0.5),
-      #                      arrowprops = dict(arrowstyle = '->', connectionstyle = 'arc3,rad=0'))
+                plt.annotate(label, xy = (x, y), horizontalalignment = 'center', verticalalignment = 'center')
 
         ratio = float(msz[0])/(msz[0]+msz[1])
         fig.set_size_inches((1-ratio)*15, ratio*15)

--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -23,12 +23,12 @@ class UMatrixView(MatplotView):
 
         return Umatrix.reshape(som.codebook.mapsize)
 
-    def show(self, som, distance2=1, row_normalized=False, show_data=True, contooor=True, blob=False):
+    def show(self, som, distance2=1, row_normalized=False, show_data=True, contooor=True, blob=False, labels = False):
         umat = self.build_u_matrix(som, distance=distance2, row_normalized=row_normalized)
         msz = som.codebook.mapsize
         proj = som.project_data(som.data_raw)
         coord = som.bmu_ind_to_xy(proj)
-
+        
         fig, ax = plt.subplots(1, 1)
         im = imshow(umat, cmap=plt.cm.get_cmap('RdYlBu_r'), alpha=1)
 
@@ -42,6 +42,17 @@ class UMatrixView(MatplotView):
 
         if show_data:
             plt.scatter(coord[:, 1], coord[:, 0], s=2, alpha=1., c='Gray', marker='o', cmap='jet', linewidths=3, edgecolor='Gray')
+            
+            if labels:
+                if labels == True:
+                  labels = self._dlabel
+                for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
+                    plt.annotate(
+                        label, 
+                        xy = (x, y), xytext = (-20, 20),
+                        textcoords = 'offset points', ha = 'right', va = 'bottom',
+                        bbox = dict(boxstyle = 'round,pad=0.5', fc = 'yellow', alpha = 0.5),
+                        arrowprops = dict(arrowstyle = '->', connectionstyle = 'arc3,rad=0'))
             plt.axis('off')
 
         ratio = float(msz[0])/(msz[0]+msz[1])

--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -48,7 +48,7 @@ class UMatrixView(MatplotView):
             if labels == True:
               labels = som.build_data_labels()
             for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
-                plt.annotate(label, xy = (x, y), horizontalalignment = 'center', verticalalignment = 'center')
+                plt.annotate(str(label), xy = (x, y), horizontalalignment = 'center', verticalalignment = 'center')
 
         ratio = float(msz[0])/(msz[0]+msz[1])
         fig.set_size_inches((1-ratio)*15, ratio*15)

--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -42,18 +42,20 @@ class UMatrixView(MatplotView):
 
         if show_data:
             plt.scatter(coord[:, 1], coord[:, 0], s=2, alpha=1., c='Gray', marker='o', cmap='jet', linewidths=3, edgecolor='Gray')
-            
-            if labels:
-                if labels == True:
-                  labels = self._dlabel
-                for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
-                    plt.annotate(
-                        label, 
-                        xy = (x, y), xytext = (-20, 20),
-                        textcoords = 'offset points', ha = 'right', va = 'bottom',
-                        bbox = dict(boxstyle = 'round,pad=0.5', fc = 'yellow', alpha = 0.5),
-                        arrowprops = dict(arrowstyle = '->', connectionstyle = 'arc3,rad=0'))
             plt.axis('off')
+            
+        if labels:
+            if labels == True:
+              labels = self._dlabel
+            for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
+                plt.annotate(
+                    label, 
+                    xy = (x, y),
+                    horizontalalignment = 'center', verticalalignment = 'center'
+                    ) #, xytext = (-20, 20),
+      #                        textcoords = 'offset points', ha = 'right', va = 'bottom',
+      #                       bbox = dict(boxstyle = 'round,pad=0.5', fc = 'yellow', alpha = 0.5),
+      #                      arrowprops = dict(arrowstyle = '->', connectionstyle = 'arc3,rad=0'))
 
         ratio = float(msz[0])/(msz[0]+msz[1])
         fig.set_size_inches((1-ratio)*15, ratio*15)


### PR DESCRIPTION
If  ```labels == True``` labels are generated using ```build_data_labels()```, if ```labels``` is a list of strings then those are used instead.

So all I added the following within the ```show()``` method of UMatrixView:

```python
if labels:
    if labels == True:
      labels = som.build_data_labels()
    for label, x, y in zip(labels, coord[:, 1], coord[:, 0]):
        plt.annotate(str(label), xy = (x, y), horizontalalignment = 'center', verticalalignment = 'center')
```