### PR TITLE
python3 compability - changing __init__ files for python3 compability…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore compiled files
+*.pyc

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 from logging.config import dictConfig
 import matplotlib
 
-matplotlib.use('Agg')  # Use whatever backend is available
+matplotlib.use('TkAgg')  # Use whatever backend is available
 
 dictConfig({
     "version": 1,
@@ -26,6 +26,6 @@ dictConfig({
 
 
 
-from sompy import SOMFactory
-from visualization import *
+from .sompy import SOMFactory
+from .visualization import *
 

--- a/codebook.py
+++ b/codebook.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sklearn.decomposition import RandomizedPCA, PCA
-from decorators import timeit
+from .decorators import timeit
 
 
 class InvalidNodeIndexError(Exception):
@@ -21,8 +21,8 @@ class Codebook(object):
 
         elif 1 == len(mapsize):
             _size = [1, mapsize[0]]
-            print 'input was considered as the numbers of nodes'
-            print 'map size is [{dlen},{dlen}]'.format(dlen=int(mapsize[0]/2))
+            print('input was considered as the numbers of nodes')
+            print('map size is [{dlen},{dlen}]'.format(dlen=int(mapsize[0]/2)))
         else:
             raise InvalidMapsizeError("Mapsize is expected to be a 2 element list or a single int")
 

--- a/sompy.py
+++ b/sompy.py
@@ -23,10 +23,10 @@ from scipy.sparse import csr_matrix
 from sklearn import neighbors
 from sklearn.externals.joblib import Parallel, delayed, load, dump
 
-from decorators import *
-from codebook import Codebook
-from neighborhood import NeighborhoodFactory
-from normalization import NormalizatorFactory
+from .decorators import *
+from .codebook import Codebook
+from .neighborhood import NeighborhoodFactory
+from .normalization import NormalizatorFactory
 
 
 class ComponentNamesError(Exception):
@@ -323,7 +323,7 @@ class SOM(object):
         row_chunk = lambda part: part * dlen // njb
         col_chunk = lambda part: min((part+1)*dlen // njb, dlen)
 
-        b = parallelizer(chunk_bmu_finder(input_matrix[row_chunk(i):col_chunk(i)], self.codebook.matrix, y2) for i in xrange(njb))
+        b = parallelizer(chunk_bmu_finder(input_matrix[row_chunk(i):col_chunk(i)], self.codebook.matrix, y2) for i in range(njb))
         bmu = np.asarray(list(itertools.chain(*b))).T
 
         del b

--- a/visualization/__init__.py
+++ b/visualization/__init__.py
@@ -1,1 +1,7 @@
-import dotmap, histogram, hitmap, mapview, umatrix
+# import dotmap, histogram, hitmap, mapview, umatrix
+from . import *
+from . import dotmap
+from . import histogram
+from . import hitmap
+from . import mapview
+from . import umatrix

--- a/visualization/mapview.py
+++ b/visualization/mapview.py
@@ -83,8 +83,8 @@ class View2DPacked(MapView):
         
 
     def show(self, som, what='codebook', which_dim='all', CMAP=None, col_sz=None):
-    	if col_sz == None:
-    		col_sz = 6
+        if col_sz == None:
+            col_sz = 6
         self.width, self.height, indtoshow, no_row_in_plot, no_col_in_plot, axisNum = self._calculate_figure_params(som, which_dim,col_sz)
         codebook = som.codebook.matrix
 
@@ -98,7 +98,7 @@ class View2DPacked(MapView):
             self.width = no_col_in_plot*2.5*(1+w)
             self.height = no_row_in_plot*2.5*(1+h)
             self.prepare()
-			
+
             while axisNum < len(indtoshow):
                 axisNum += 1
                 ax = self._fig.add_subplot(no_row_in_plot, no_col_in_plot, axisNum)

--- a/visualization/umatrix.py
+++ b/visualization/umatrix.py
@@ -1,5 +1,6 @@
 import matplotlib
 from .view import MatplotView
+matplotlib.use('TkAgg')
 from matplotlib import pyplot as plt
 from pylab import meshgrid, cm, imshow, contour, clabel, colorbar, axis, title, show
 from math import sqrt


### PR DESCRIPTION
1. Python 3 
__init__ files were modified to be python 3 compatible
Python 2 backward compatibility tested 

2. .gitignore added to ignore .pyc files

3. matplotlib issue on ubuntu x64 - matplotlib using 'Agg' gives an error that the system has no x-window system for viewing plots. It only worked with TkAgg.

4. Python mixed indentation (spaces/tabs) error in visualization/mapview.py 

