### PR TITLE
Fix a matplotlib Normalize function call typo.

### DIFF
--- a/sompy/visualization/mapview.py
+++ b/sompy/visualization/mapview.py
@@ -57,7 +57,7 @@ class View2D(MapView):
         self.prepare()
         codebook = som.codebook.matrix
 
-        norm = matplotlib.colors.normalize(
+        norm = matplotlib.colors.Normalize(
             vmin=np.mean(codebook.flatten()) - 1 * np.std(codebook.flatten()),
             vmax=np.mean(codebook.flatten()) + 1 * np.std(codebook.flatten()),
             clip=True)


### PR DESCRIPTION
I found that in the matplotlib 1.5.3-np111py27_0 version (the newest one) the method matplotlib.colors.normalize does not exist; the correct method name is matplotlib.colors.Normalize. It was a convention violation in class names which was deprecated. 