### PR TITLE
fix: component names

### DIFF
--- a/sompy/sompy.py
+++ b/sompy/sompy.py
@@ -46,7 +46,8 @@ class SOMFactory(object):
               initialization='pca',
               neighborhood='gaussian',
               training='batch',
-              name='sompy'):
+              name='sompy',
+              component_names=None):
         """
         :param data: data to be clustered, represented as a matrix of n rows,
             as inputs and m cols as input features
@@ -87,7 +88,7 @@ class SOMFactory(object):
         neighborhood_calculator = NeighborhoodFactory.build(neighborhood)
 
         return SOM(data, neighborhood_calculator, normalizer, mapsize, mask,
-                   mapshape, lattice, initialization, training, name)
+                   mapshape, lattice, initialization, training, name, component_names)
 
 
 class SOM(object):
@@ -102,7 +103,8 @@ class SOM(object):
                  lattice='rect',
                  initialization='pca',
                  training='batch',
-                 name='sompy'):
+                 name='sompy',
+                 component_names=None):
         """
         Self Organizing Map
 
@@ -134,8 +136,7 @@ class SOM(object):
         self.mask = mask or np.ones([1, self._dim])
         self.codebook = Codebook(mapsize, lattice)
         self.training = training
-
-        self._component_names = self.build_component_names()
+        self._component_names = self.build_component_names() if component_names is None else [component_names]
         self._distance_matrix = self.calculate_map_dist()
 
     @property

--- a/sompy/visualization/mapview.py
+++ b/sompy/visualization/mapview.py
@@ -57,6 +57,13 @@ class View2D(MapView):
         self.prepare()
         codebook = som.codebook.matrix
 
+        if which_dim == 'all':
+            names = som._component_names[0]
+        elif type(which_dim) == int:
+            names = [som._component_names[0][which_dim]]
+        elif type(which_dim) == list:
+            names = som._component_names[0][which_dim]
+
         norm = matplotlib.colors.normalize(
             vmin=np.mean(codebook.flatten()) - 1 * np.std(codebook.flatten()),
             vmax=np.mean(codebook.flatten()) + 1 * np.std(codebook.flatten()),
@@ -70,6 +77,7 @@ class View2D(MapView):
                                           som.codebook.mapsize[1])
             pl = plt.pcolor(mp[::-1], norm=norm)
             plt.axis([0, som.codebook.mapsize[0], 0, som.codebook.mapsize[1]])
+            plt.title(names[axis_num - 1])
             ax.set_yticklabels([])
             ax.set_xticklabels([])
             plt.colorbar(pl)


### PR DESCRIPTION
Implemented the component names injection in the components plot. Add an option to choose custom component names. If not specified, Variable-# is written as a tittle of each component. Example of usage:

`sm = SOMFactory().build(array, mapsize = [msz, msz], normalization = 'var', initialization='pca', component_names = vector_of_names)`

`sm.train(n_job=1, verbose="info")`