### PR TITLE
Fix on the code responsible for calculating the color scale bounds.

### DIFF
--- a/sompy/visualization/mapview.py
+++ b/sompy/visualization/mapview.py
@@ -79,10 +79,15 @@ class View2D(MapView):
             axis_num += 1
             ax = plt.subplot(no_row_in_plot, no_col_in_plot, axis_num)
             ind = int(indtoshow[axis_num-1])
-            norm = matplotlib.colors.Normalize(
-                vmin=np.mean(codebook[:, ind].flatten()) - 1 * np.std(codebook[:, ind].flatten()),
-                vmax=np.mean(codebook[:, ind].flatten()) + 1 * np.std(codebook[:, ind].flatten()),
-                clip=True)
+
+            min_color_scale = np.mean(codebook[:, ind].flatten()) - 1 * np.std(codebook[:, ind].flatten())
+            max_color_scale = np.mean(codebook[:, ind].flatten()) + 1 * np.std(codebook[:, ind].flatten())
+            min_color_scale = min_color_scale if min_color_scale >= min(codebook[:, ind].flatten()) else \
+                min(codebook[:, ind].flatten())
+            max_color_scale = max_color_scale if max_color_scale <= max(codebook[:, ind].flatten()) else \
+                max(codebook[:, ind].flatten())
+            norm = matplotlib.colors.Normalize(vmin=min_color_scale, vmax=max_color_scale, clip=True)
+
             mp = codebook[:, ind].reshape(som.codebook.mapsize[0],
                                           som.codebook.mapsize[1])
             pl = plt.pcolor(mp[::-1], norm=norm)


### PR DESCRIPTION
The original code calculated the bounds of the color scale as the mean of the variable plus-minus 1 standard deviation. This is a good choice, specially for outliers. The problem is that it assumes that the distribution is symmetric, i.e. not skewed. If the distribution is skewed enough, one of the bounds calculated may lay out of the distribution and a part of the distribution be not used. For solving it fast, I applied two max-min conditions on top of the criteria already implemented, that way the whole color scale utilisation is assured.