### PR TITLE
Fix a raw data mutation occurring when auto-calculating the map size.

### DIFF
--- a/sompy/sompy.py
+++ b/sompy/sompy.py
@@ -606,11 +606,11 @@ class SOM(object):
 
     def calculate_map_size(self, lattice):
         """
-        :lattice: 'rect' or 'hex'
         Calculates the optimal map size given a dataset using eigenvalues and eigenvectors. Matlab ported
+        :lattice: 'rect' or 'hex'
         :return: map sizes
         """
-        D = self.data_raw
+        D = self.data_raw.copy()
         dlen = D.shape[0]
         dim = D.shape[1]
         munits = np.ceil(5 * (dlen ** 0.5))


### PR DESCRIPTION
Sorry, I commited a horrible bug when I did my last bunch of contributions. Due to a numpy referenced object, when the optimal size of the map was calculated, the values of the original data also changed. I solved the problem by making a copy of the original data when calculating the map size. 

I think it would be a great idea to use unit tests and Travis, like all the big projects (Sklearn, Pandas, XGBoost, etc.) to try to avoid this kind of bugs in the future... If I have time, I will create an initial version of it :D.

Iván.