### PR TITLE
ipdb seems to cause MultipleInstanceErrors in Jupyter

### DIFF
--- a/sompy/sompy.py
+++ b/sompy/sompy.py
@@ -29,7 +29,8 @@ from .neighborhood import NeighborhoodFactory
 from .normalization import NormalizatorFactory
 
 #lbugnon
-import sompy,ipdb
+#import ipdb
+import sompy
 #
 
 class ComponentNamesError(Exception):

--- a/sompy/visualization/mapview.py
+++ b/sompy/visualization/mapview.py
@@ -2,7 +2,7 @@ import matplotlib
 from .view import MatplotView
 from matplotlib import pyplot as plt
 import numpy as np
-import ipdb
+#import ipdb
 
 
 class MapView(MatplotView):


### PR DESCRIPTION
I get the following error when using SOMPY with Anaconda Python 2.7 running in Jupyter: 

'Multiple incompatible subclass instances of TerminalIPythonApp are being created.'

Since `ipdb` doesn't actually seem to be used in the master that I forked, I've just commented these out and the code seems to work again.