### PR TITLE
Docs: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SOMPY has the following dependencies (tested only with Python 2.7x):
 - numexpr
 - matplotlib
 - pandas
+- ipdb
 
 ### Installation:
 ```Python


### PR DESCRIPTION
The library `ipdb` was also required in my case.