### PR TITLE
UMatrixView save figure fix

### DIFF
--- a/sompy/visualization/umatrix.py
+++ b/sompy/visualization/umatrix.py
@@ -35,7 +35,7 @@ class UMatrixView(MatplotView):
         proj = som.project_data(som.data_raw)
         coord = som.bmu_ind_to_xy(proj)
 
-        fig, ax = plt.subplots(1, 1)
+        self._fig, ax = plt.subplots(1, 1)
         imshow(umat, cmap=plt.cm.get_cmap('RdYlBu_r'), alpha=1)
 
         if contooor:
@@ -61,7 +61,7 @@ class UMatrixView(MatplotView):
                              verticalalignment='center')
 
         ratio = float(msz[0])/(msz[0]+msz[1])
-        fig.set_size_inches((1-ratio)*15, ratio*15)
+        self._fig.set_size_inches((1-ratio)*15, ratio*15)
         plt.tight_layout()
         plt.subplots_adjust(hspace=.00, wspace=.000)
         sel_points = list()


### PR DESCRIPTION
(Tested on Anaconda Python 2.7 and 3.6)

Trying to save a UMatrixView directly in the code like this:
`u = UMatrixView(20, 20, 'umatrix', show_axis=True, text_size=8, show_text=True)`
`UMAT = u.build_u_matrix(som, distance=1, row_normalized=False)`
`u.show(som, distance2=1, row_normalized=False, show_data=True, contooor=True, blob=False)`
`u.save("test file umat")`

 gives this error:
"
File "C:\Users\user1\PycharmProjects\myproject\site-packages\sompy\visualization\view.py", line 50, in save
    self._fig.savefig(filename, transparent=transparent, dpi=dpi,
**AttributeError: 'NoneType' object has no attribute 'savefig**
'"
because the _fig attribute of MatplotView has not been set and is still None. My small update fixes that.