### PR TITLE
Code crashes on mapsize[0] * mapsize[1]

### DIFF
--- a/sompy/codebook.py
+++ b/sompy/codebook.py
@@ -41,7 +41,7 @@ class Codebook(object):
                 "Mapsize is expected to be a 2 element list or a single int")
 
         self.mapsize = _size
-        self.nnodes = mapsize[0]*mapsize[1]
+        self.nnodes = self.mapsize[0]*self.mapsize[1]
         self.matrix = np.asarray(self.mapsize)
         self.initialized = False
 


### PR DESCRIPTION
This needs to be changed to self.mapsize[0]* self.mapsize[1] 
If one value is passed to the mapsize eg: mapsize[1000], this indicates the number of nodes

_size = [1, mapsize[0]] this creates a new array , [1,1000]
 self.mapsize = _size assigns newarray to self.mapsize.

self.nnodes = mapsize[0]*mapsize[1].. here mapsize is still the old array that was passed as a parameter [1000] * outof bound index, throws error