### PR TITLE
Updating dependency on joblib (sklearn >= 0.21)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
-
 setup(
     name="SOMPY",
-    version="1.0",
+    version="1.1",
     description="Self Organizing Maps Package",
     author="Vahid Moosavi and Sebastian Packmann",
     packages=find_packages(),
     install_requires=['numpy >= 1.7', 'scipy >= 0.9',
-                      'scikit-learn >= 0.16', 'numexpr >= 2.5']
+                      'scikit-learn >= 0.21', 'numexpr >= 2.5']
 )

--- a/sompy/sompy.py
+++ b/sompy/sompy.py
@@ -20,7 +20,7 @@ from multiprocessing.dummy import Pool
 from multiprocessing import cpu_count
 from scipy.sparse import csr_matrix
 from sklearn import neighbors
-from sklearn.externals.joblib import Parallel, delayed, load, dump
+from joblib import Parallel, delayed, load, dump
 import sys
 
 from .decorators import timeit


### PR DESCRIPTION
This addresses a deprecation warning on sklearn >= 0.21 that sklearn.externals.joblib should be replaced by the now distinct joblib library. 

**However**, updating past sklearn 0.20 means that Python 2.7 and 3.4 are no longer supported. For that reason I've incremented the release to 1.1 in setup.py and adjusted the requirements accordingly but you may wish to take another strategy if retaining Python 2 support is important.

**Also**, by default pip is still installing 0.1.1 (and only lists 0.1.0 as an alternative) so I think there are a couple of distributions that need to be pushed to public availability.