### PR TITLE
Fixed rows order in BMUHitsView and HitMapView to match the View2D fe…

### DIFF
--- a/sompy/visualization/bmuhits.py
+++ b/sompy/visualization/bmuhits.py
@@ -3,6 +3,7 @@ from collections import Counter
 import matplotlib
 import numpy as np
 from matplotlib import pyplot as plt
+from itertools import chain
 
 from .mapview import MapView
 
@@ -59,11 +60,12 @@ class BmuHitsView(MapView):
             ax.set_yticklabels([])
             ax.set_xticklabels([])
             plt.colorbar(pl)
-
             #plt.show()
         elif som.codebook.lattice == "hexa":
-            ax, cents = plot_hex_map(mp[::-1], colormap=cmap, fig=self._fig)
+            ax, cents = plot_hex_map(mp, colormap=cmap, fig=self._fig)
             if anotate:
-                self._set_labels(cents, ax, reversed(counts), onlyzeros, labelsize, hex=True)
+                reversedcounts = np.array(counts[::-1])
+                orderedcounts = list(chain.from_iterable(np.flip(reversedcounts.reshape(msz[0], msz[1])[::],axis=0)))
+                self._set_labels(cents, ax, orderedcounts, onlyzeros, labelsize, hex=True)
             #plt.show()
         #return ax, cents

--- a/sompy/visualization/hitmap.py
+++ b/sompy/visualization/hitmap.py
@@ -2,6 +2,7 @@ from .view import MatplotView
 from sompy.visualization.plot_tools import plot_hex_map
 from matplotlib import pyplot as plt
 import numpy as np
+from itertools import chain
 
 from .mapview import MapView
 
@@ -42,16 +43,18 @@ class HitMapView(MapView):
                 if anotate:
                     # TODO: Fix position of the labels
                     self._set_labels(cents, ax, clusters[proj], onlyzeros, labelsize, hex=False)
-
             else:
                 cents = som.bmu_ind_to_xy(np.arange(0, msz[0]*msz[1]))
                 if anotate:
                     # TODO: Fix position of the labels
-                    self._set_labels(cents, ax, clusters, onlyzeros, labelsize, hex=False)
+                    orderedclusters = list(chain.from_iterable(np.flip(clusters.reshape(msz[0], msz[1])[::],axis=0)))
+                    self._set_labels(cents, ax, orderedclusters, onlyzeros, labelsize, hex=False)
 
-            plt.imshow(np.flip(clusters.reshape(msz[0], msz[1])[::],axis=0), alpha=0.5)
+            plt.axis('off')
+            plt.imshow(clusters.reshape(msz[0], msz[1])[::], alpha=0.5)
 
         elif som.codebook.lattice == "hexa":
-            ax, cents = plot_hex_map(np.flip(clusters.reshape(msz[0], msz[1])[::], axis=0),  fig=self._fig, colormap=cmap, colorbar=False)
+            ax, cents = plot_hex_map(clusters.reshape(msz[0], msz[1])[::],  fig=self._fig, colormap=cmap, colorbar=False)
             if anotate:
-                self._set_labels(cents, ax, reversed(clusters), onlyzeros, labelsize, hex=True)
+                orderedclusters = list(chain.from_iterable(np.flip(clusters[::-1].reshape(msz[0], msz[1])[::],axis=0)))
+                self._set_labels(cents, ax, orderedclusters, onlyzeros, labelsize, hex=True)


### PR DESCRIPTION
Found the row order in BMUHitsView (hexa only) and HitMapView (rect and hexa both) is wrong in comparing with View2D feature maps. Fixed. Checked with Python 3.9.7 (Anaconda) and matplotlib 3.4.3